### PR TITLE
Confine grep_codebase searches to the current repository

### DIFF
--- a/tests/test_actions/test_grep_codebase.py
+++ b/tests/test_actions/test_grep_codebase.py
@@ -37,6 +37,43 @@ async def test_grep_happy_path(
     assert "needle" in result.output
 
 
+async def test_grep_rejects_path_outside_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, require_rg: str
+) -> None:
+    _init_repo(tmp_path)
+    outside = tmp_path.parent / f"{tmp_path.name}-outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("outside marker\n")
+    monkeypatch.chdir(tmp_path)
+
+    result = await GrepCodebaseAction({}).execute(
+        pattern="outside marker", path=str(outside)
+    )
+
+    assert result.success is False
+    assert "outside the current repo" in result.output
+    assert "outside marker" not in result.output
+
+
+async def test_grep_accepts_path_inside_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, require_rg: str
+) -> None:
+    _init_repo(tmp_path)
+    source = tmp_path / "src"
+    source.mkdir()
+    (source / "a.txt").write_text("inside marker\n")
+    (tmp_path / "root.txt").write_text("inside marker\n")
+    monkeypatch.chdir(tmp_path)
+
+    result = await GrepCodebaseAction({}).execute(
+        pattern="inside marker", path="src"
+    )
+
+    assert result.success is True
+    assert "src" in result.output
+    assert "root.txt" not in result.output
+
+
 async def test_grep_missing_pattern() -> None:
     result = await GrepCodebaseAction({}).execute(pattern="")
     assert result.success is False

--- a/tokenpal/actions/grep_codebase.py
+++ b/tokenpal/actions/grep_codebase.py
@@ -9,7 +9,7 @@ from typing import Any, ClassVar
 from tokenpal.actions.base import AbstractAction, ActionResult
 from tokenpal.actions.registry import register_action
 from tokenpal.brain.personality import contains_sensitive_term
-from tokenpal.util.paths import git_root
+from tokenpal.util.paths import git_root, resolve_inside
 from tokenpal.util.proc import run_capture
 
 # Total lines returned to the caller, enforced in Python: ripgrep has no
@@ -60,7 +60,12 @@ class GrepCodebaseAction(AbstractAction):
             if contains_sensitive_term(path_arg):
                 return ActionResult(output="Path references a sensitive app.", success=False)
             candidate = Path(path_arg)
-            target = candidate if candidate.is_absolute() else (root / candidate)
+            match = resolve_inside(candidate, [root])
+            if match is None:
+                return ActionResult(
+                    output="Search path is outside the current repo.", success=False
+                )
+            target = match[0]
         else:
             target = root
 


### PR DESCRIPTION
## Summary

`grep_codebase` accepted absolute paths and parent-directory paths. When the local tool was enabled, that allowed a search to return file contents from outside the current repository.

## Changes

- Route explicit search paths through the shared `resolve_inside` repository-containment helper.
- Reject absolute, `..`, and symlink-escaping paths outside the current repository without echoing the rejected path.
- Preserve the default repository-root search and valid in-repository subdirectory searches.
- Add regression coverage for both outside-repository rejection and in-repository subdirectory behavior.

## Validation

- Focused tests: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -p pytest_asyncio.plugin --basetemp=_tokenpal-pytest-tmp tests/test_actions/test_grep_codebase.py -q` — 8 passed.
- Changed-file lint: `python -m ruff check tokenpal/actions/grep_codebase.py tests/test_actions/test_grep_codebase.py` — passed.
- Wheel build: `python -m build --wheel --no-isolation` — passed.
- Full suite: 2272 passed, 22 skipped, 34 failed, and 20 errors on Windows. The remaining failures are baseline environment limitations involving symlink privileges, Windows permissions, default encoding, platform behavior, and optional Qt dependencies; no changed grep test failed.
- Full-repository Ruff, mypy, and format checks report pre-existing findings outside this change, so no unrelated formatting or cleanup was included.

## Compatibility

Valid relative and absolute paths inside the current repository continue to work. Paths that resolve outside the repository are refused before `rg` runs.

Fixes #74
